### PR TITLE
add "login all URLs" configuration option

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/PluginImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/PluginImpl.java
@@ -65,6 +65,7 @@ public class PluginImpl extends Plugin {
     private String loginServerModule = "spnego-server";
     private String loginClientModule = "spnego-client";
 
+    private boolean loginAllURLs = false;
     private boolean allowLocalhost = true;
     private boolean allowBasic = true;
     private boolean allowDelegation = false;
@@ -146,9 +147,10 @@ public class PluginImpl extends Plugin {
 
             if (!data.has("account") || !data.has("password") || !data.has("krb5Location")
                     || !data.has("loginLocation") || !data.has("loginServerModule")
-                    || !data.has("loginClientModule") || !data.has("allowLocalhost")
-                    || !data.has("allowBasic") || !data.has("allowDelegation")
-                    || !data.has("promptNtlm") || !data.has("allowUnsecureBasic")) {
+                    || !data.has("loginClientModule") || !data.has("loginAllURLs")
+                    || !data.has("allowLocalhost") || !data.has("allowBasic")
+                    || !data.has("allowDelegation") || !data.has("promptNtlm")
+                    || !data.has("allowUnsecureBasic")) {
 
                 throw new Descriptor.FormException("Malformed form recieved. Try again.", "enabled");
             }
@@ -185,6 +187,7 @@ public class PluginImpl extends Plugin {
 
             this.loginServerModule = (String)data.get("loginServerModule");
             this.loginClientModule = (String)data.get("loginClientModule");
+            this.loginAllURLs = (Boolean)data.get("loginAllURLs");
             this.allowLocalhost = (Boolean)data.get("allowLocalhost");
             this.allowBasic = (Boolean)data.get("allowBasic");
             this.allowDelegation = (Boolean)data.get("allowDelegation");
@@ -287,6 +290,15 @@ public class PluginImpl extends Plugin {
      */
     public String getLoginClientModule() {
         return loginClientModule;
+    }
+
+    /**
+     * Used by groovy for data-binding.
+     * @return whether the user has requested login prompts for all URLs or
+     * just the "/login" one.
+     */
+    public boolean loginAllURLs() {
+        return loginAllURLs;
     }
 
     /**

--- a/src/main/resources/com/sonymobile/jenkins/plugins/kerberossso/PluginImpl/config.groovy
+++ b/src/main/resources/com/sonymobile/jenkins/plugins/kerberossso/PluginImpl/config.groovy
@@ -69,6 +69,10 @@ form.section(title:"Kerberos Single Sign-On") {
                 form.textbox(value:my.loginClientModule)
             }
 
+            form.entry(title:_("Login All URLs"), help:location+"/help-login-all-urls.html") {
+                form.checkbox(field: "loginAllURLs", checked:my.loginAllURLs)
+            }
+
             form.entry(title:_("Allow Localhost"), help:location+"/help-allow-localhost.html") {
                 form.checkbox(field: "allowLocalhost", checked:my.allowLocalhost)
             }

--- a/src/main/webapp/help-login-all-urls.html
+++ b/src/main/webapp/help-login-all-urls.html
@@ -1,0 +1,4 @@
+<div>
+    When this box is checked, the plugin will force users to log in via Kerberos for all URLs they visit. This has the side effect that "log out" is essentially ineffective.<br />
+When this box is unchecked, the plugin will only operate on the "/login" URL. Users have to click the "log in" link at the top of the page in order to authenticate. By leaving this box unchecked, you can permit anonymous users to still have access to Jenkins.
+</div>

--- a/src/test/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosFilterTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosFilterTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.login.LoginException;
@@ -98,7 +99,9 @@ public class KerberosFilterTest {
         });
         PluginServletFilter.addFilter(filter);
 
-        HtmlPage mainPage = rule.createWebClient().goTo("");
+        WebClient wc = rule.createWebClient();
+        wc.goTo("login");
+        HtmlPage mainPage = wc.goTo("");
 
         assertNotNull(mainPage);
         assertTrue(mainPage.asText().contains("mockUser"));
@@ -127,7 +130,9 @@ public class KerberosFilterTest {
         });
         PluginServletFilter.addFilter(filter);
 
-        HtmlPage mainPage = rule.createWebClient().goTo("");
+        WebClient wc = rule.createWebClient();
+        wc.goTo("login");
+        HtmlPage mainPage = wc.goTo("");
 
         assertNotNull(mainPage);
         assertTrue(((HtmlAnchor)mainPage.getFirstByXPath(


### PR DESCRIPTION
Prior to this change, the plugin's filter acted on all URLs. This meant that users were logged in right away. This also meant that it was impossible to log out, or to grant anonymous users any effective level of access (authentication was effectively mandatory).

Add a new "login all URLs" configuration option. This makes "log in" work similarly to the OpenID plugin:

- users have to click "log in",
- the "log out" button works,
- administrators have the option of granting access to anonymous users.