### PR TITLE
[JENKINS-44484] Fixed redirect when Jenkins has a context path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <!-- RestartableJenkinsRule and SecurityListener#fireLoggedIn -->
-    <jenkins.version>1.568</jenkins.version>
+    <jenkins.version>1.651.2</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.16</jenkins-test-harness.version>
   </properties>

--- a/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosSSOFilter.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosSSOFilter.java
@@ -251,6 +251,15 @@ public class KerberosSSOFilter implements Filter {
         String from = Util.fixEmptyAndTrim(req.getParameter("from"));
         // see Jenkins.doLoginEntry
         if (from != null && from.startsWith("/") && !from.equals("/loginError")) {
+            // Imported from hudson.security.AuthenticationProcessingFilter2.determineTargetUrl
+            if (!Util.isSafeToRedirectTo(from))
+                return contextPath; // avoid open redirect
+
+            // Based on code from hudson.security.AuthenticationProcessingFilter2.determineTargetUrl
+            // handles case where 'from' contains Context Path
+            if(from.startsWith(contextPath))
+                return from;
+            
             return contextPath + from;
         }
 

--- a/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosSSOFilter.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosSSOFilter.java
@@ -252,14 +252,16 @@ public class KerberosSSOFilter implements Filter {
         // see Jenkins.doLoginEntry
         if (from != null && from.startsWith("/") && !from.equals("/loginError")) {
             // Imported from hudson.security.AuthenticationProcessingFilter2.determineTargetUrl
-            if (!Util.isSafeToRedirectTo(from))
+            if (!Util.isSafeToRedirectTo(from)) {
                 return contextPath; // avoid open redirect
+            }
 
             // Based on code from hudson.security.AuthenticationProcessingFilter2.determineTargetUrl
             // handles case where 'from' contains Context Path
-            if(from.startsWith(contextPath))
+            if (from.startsWith(contextPath)) {
                 return from;
-            
+            }
+
             return contextPath + from;
         }
 

--- a/src/test/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosFilterTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/kerberossso/KerberosFilterTest.java
@@ -301,6 +301,23 @@ public class KerberosFilterTest {
         assertThat(page.getWebResponse().getWebRequest().getUrl(), equalTo(rule.getURL()));
     }
 
+    @Test
+    public void redirectBackWithContextPath() throws Exception {
+        fakePrincipal("this_will_be_ignored@TEST.COM");
+        PluginImpl.getInstance().setAnonymousAccess(true);
+
+        wc = rule.createWebClient();
+        injectDummyCredentials();
+
+        // The test Jenkins already includes /jenkins as the context path so send that in the from
+        HtmlPage page = wc.goTo("login?from=/jenkins/whoAmI");
+        assertThat(page.asText(), authenticated());
+        assertThat(
+                page.getWebResponse().getWebRequest().getUrl().toExternalForm(),
+                equalTo(rule.getURL().toExternalForm() + "whoAmI/")
+        );
+    }
+
     private void injectDummyCredentials() {
         String dummyRealmCreds = "mockUser:mockUser";
         wc.addRequestHeader("Authorization", "Basic " + Base64.encode(dummyRealmCreds.getBytes()));


### PR DESCRIPTION
Used AuthenticationProcessingFilter2 as a basis for the redirect code
Upgraded jenkins version to use Util.isSafeToRedirectTo
Added test with context path