### PR TITLE
Updated to support testing under Jenkins 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>2.37</version>
   </parent>
 
   <groupId>com.sonymobile.jenkins.plugins.kerberos-sso</groupId>
@@ -18,7 +18,8 @@
     <!-- RestartableJenkinsRule and SecurityListener#fireLoggedIn -->
     <jenkins.version>1.651.2</jenkins.version>
     <java.level>7</java.level>
-    <jenkins-test-harness.version>2.16</jenkins-test-harness.version>
+    <!-- Version 2.24+ brings in Jetty 9.4.5 which breaks the CLI test under Jenkins < 2.61 -->
+    <jenkins-test-harness.version>2.23</jenkins-test-harness.version>
   </properties>
 
   <developers>
@@ -84,13 +85,18 @@
       <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>4.11</version>
           <scope>test</scope>
       </dependency>
       <dependency>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-all</artifactId>
           <version>1.10.19</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>apache-httpcomponents-client-4-api</artifactId>
+          <version>4.5.3-2.1</version>
           <scope>test</scope>
       </dependency>
   </dependencies>
@@ -133,7 +139,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>always</forkMode>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Jenkins 2.54 changed CLI parameters
Jenkins 2.54 made CLI over SSH disabled by default
Jenkins 2.44 disabled user creation via Jenkins.getUser
Changed to Http Components client since Jenkins deprecated the Apache Commons httpclient
Upgraded pom versions to support Jenkins 2.x

All of these changes are to support testing for [JENKINS-55698](https://issues.jenkins-ci.org/browse/JENKINS-55698).  Fixing that bug will require more changes.

Testing Jenkins 2.61+ can and sometimes needs the test harness version to be updated.  Here's the arguments I've been using.

`mvn clean verify -Djenkins.version=2.150.1 -Djava.level=8 -Djenkins-test-harness.version=2.31`