### PR TITLE
[JENKINS-55698] Fixed issues with the User Seed after SECURITY-901

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.25</version>
+    <version>3.34</version>
   </parent>
 
   <groupId>com.sonymobile.jenkins.plugins.kerberos-sso</groupId>
@@ -15,7 +15,7 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Kerberos+SSO+Plugin</url>
 
   <properties>
-    <jenkins.version>2.73</jenkins.version>
+    <jenkins.version>2.150.2</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -95,6 +95,11 @@
           <artifactId>apache-httpcomponents-client-4-api</artifactId>
           <version>4.5.3-2.1</version>
           <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.kohsuke</groupId>
+          <artifactId>access-modifier-suppressions</artifactId>
+          <version>1.16</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
Included code from AuthenticationProcessingFilter2 to fix issues with User Seed
Updated minimum version of Jenkins to 2.150.2 to use the new UserSeedProperty
Updated Plugin pom to 3.34 to pull in newer version of access-modifier-checker
Included access-modifier-supressions to suppress restrictions on UserSeedProperty

Due to the new version of Jenkins there are a number of deprecations that are not fixed in this PR.

I've had to suppress the restriction on the UserSeedProperty since it was left restricted after being merged.  There is a TODO in the code that talks about removing the restriction but that seems like it hasn't been done, see https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/security/seed/UserSeedProperty.java#L61.  I don't know what will become a public API on the UserSeedProperty so I can't tell if this fix needs to be rewritten but for now it fixes the issue.