### PR TITLE
chore(Jenkinsfile) only use standard Linux docker agents (JENKINS-66924)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(configurations: [
     [ platform: "windows", jdk: "8", jenkins: null ],
-    [ platform: "docker && highmem", jdk: "8", jenkins: null ],
-    [ platform: "docker && highmem", jdk: "11", jenkins: "2.164.3" /*Java 11 not supported for any older release*/ ]
+    [ platform: "linux && docker", jdk: "8", jenkins: null ],
+    [ platform: "linux && docker", jdk: "11", jenkins: "2.164.3" /*Java 11 not supported for any older release*/ ]
 ])


### PR DESCRIPTION
This PR fixes the CI build of the principal branch by ensuring that a valid set of labels is used to allocate an agent.

The main impact is that the "high memory" instances are not expected to be used: only Docker and linux are required.

It comes from https://issues.jenkins.io/browse/JENKINS-66924 (root issue is on the Jenkins infra side - https://issues.jenkins.io/browse/INFRA-3099): the usage of the "highmem" is challenged by this PR.

Either the builds are ok with the "standard VM size" for Linux and Docker (it's as 4 vCPUs / 16 Gb as per https://github.com/jenkins-infra/documentation/blob/a557876b663f4bba80416bba12f936e590b327e6/ci.adoc, when writing these words), OR we can keep using highmem, but then we have to change the current labels `docker && highmem` to `docker-highmem`.

Ping @olivergondza :)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry **(no need for changelog entry)**
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
