### PR TITLE
[FIX JENKINS-69642] Do not fail on excessive CasC fields when plugin is disabled

### DIFF
--- a/plugin/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/JcascConfigurator.java
+++ b/plugin/src/main/java/com/sonymobile/jenkins/plugins/kerberossso/JcascConfigurator.java
@@ -83,10 +83,12 @@ public class JcascConfigurator extends BaseConfigurator<PluginImpl> {
             i.setAllowDelegation(read(m, "allowDelegation", PluginImpl.DEFAULT_ALLOW_DELEGATION));
             i.setAllowUnsecureBasic(read(m, "allowUnsecureBasic", PluginImpl.DEFAULT_ALLOW_UNSECURE_BASIC));
             i.setPromptNtlm(read(m, "promptNtlm", PluginImpl.DEFAULT_PROMPT_NTLM));
-        }
 
-        if (!m.isEmpty()) {
-            throw new ConfiguratorException("Unknown field(s) specified for kerberosSso: " + m.keySet());
+            // Do not check for emptiness when plugin not enabled. Otherwise, we would have to read, and maybe even validate
+            // them all forcing user to correct the config they are trying to deactivate.
+            if (!m.isEmpty()) {
+                throw new ConfiguratorException("Unknown field(s) specified for kerberosSso: " + m.keySet());
+            }
         }
 
         i.removeFilter();

--- a/plugin/src/test/resources/com/sonymobile/jenkins/plugins/kerberossso/JcascTest/off.yaml
+++ b/plugin/src/test/resources/com/sonymobile/jenkins/plugins/kerberossso/JcascTest/off.yaml
@@ -1,3 +1,5 @@
 security:
   kerberosSso:
     enabled: false
+    krb5Location: '${KRB5_CONF}'
+    loginLocation: '${LOGIN_CONF}'


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-69642

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
