### PR TITLE
[JENKINS-75504] Use MIT license in pom and LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright 2014
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
   <packaging>hpi</packaging>
   <name>Kerberos SSO plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/license/mit/</url>
+    </license>
+  </licenses>
 
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>


### PR DESCRIPTION
## [JENKINS-75504] Use MIT license in pom and LICENSE.md file

[JENKINS-75504](https://issues.jenkins.io/browse/JENKINS-75504) reports that a license is not declared by the plugin in either its pom file or a separate LICENSE file.

Since all the Java files include an MIT license and the Jenkins project recommends the MIT license, it seems safe to add the MIT license to the pom.xml file and to create a LICENSE.md file with the MIT license.  Both the pom file segment and the LICENSE.md segment were copied from the plugin archetype.  The year of the copyright is based on the first year recorded in the git history of the plugin.

The two forms of copyright statements in the Java source files are:

 * Copyright (c) 2014 Sony Mobile Communications Inc. All rights reserved.
 * Copyright (c) Red Hat, Inc.

### Testing done

Searched the source files for license statements and confirmed that they are all MIT licenses.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
